### PR TITLE
Finish default local content plus general lint cleanup

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,4 @@
-const contentDir = '../nc-reentry-resources-content';
-module.exports = contentDir;
+const config = {
+  contentDir: '../nc-reentry-resources-content',
+};
+module.exports = config;

--- a/src/reducers/contentReducer.js
+++ b/src/reducers/contentReducer.js
@@ -1,7 +1,7 @@
 import * as types from '../actions/actionTypes';
 
 export default function contentReducer(state = {}, action) {
-  switch(action.type) {
+  switch (action.type) {
     case types.LOAD_CONTENT_SUCCESS:
       return action.content;
     default:

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -2,8 +2,8 @@ import { combineReducers } from 'redux';
 import content from './contentReducer';
 
 const rootReducer = combineReducers({
-  //ES6 shorthand property name. Could also use long form ie: content: content
-  content
+  // ES6 shorthand property name. Could also use long form ie: content: content
+  content,
 });
 
 export default rootReducer;

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,33 +2,22 @@ import Home from './components/Home.jsx';
 import App from './components/App.jsx';
 import Contact from './components/Contact.jsx';
 
-// const routes = {
-//   path: '',
-//   component: Layout,
-//   childRoutes: [
-//     {
-//       path: '/:jurisdiction/:topic',
-//       component: App,
-//     },
-//   ],
-// };
-
 const routes = {
-      path: '',
-      childRoutes: [
-        {
-          path: '/',
-          component: Home
-        },
-        {
-          path: '/:jurisdiction/:topic',
-          component: App
-        },
-        {
-          path: '/contact',
-          component: Contact
-        }
-      ]
+  path: '',
+  childRoutes: [
+    {
+      path: '/',
+      component: Home,
+    },
+    {
+      path: '/:jurisdiction/:topic',
+      component: App,
+    },
+    {
+      path: '/contact',
+      component: Contact,
+    },
+  ],
 };
 
 export { routes };

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 /* eslint no-console: 0 */
 import React from 'react';
+import { Provider } from 'react-redux';
 import { renderToString } from 'react-dom/server';
 import { match, RouterContext } from 'react-router';
 import express from 'express';
@@ -8,9 +9,6 @@ import path from 'path';
 import compose from './server/compose';
 import { routes } from './routes';
 import configureStore from './store/configureStore';
-import { Provider } from 'react-redux';
-import App from './components/App.jsx';
-import Home from './components/Home.jsx';
 
 const app = express();
 require('node-jsx').install();
@@ -57,24 +55,24 @@ app.get('*', (req, res) => {
         // console.log(preloadedState);
 
         const store = configureStore(preloadedState);
-        console.log('store');
-        console.log(store.getState());
+        // console.log('store');
+        // console.log(store.getState());
 
         const markup = renderToString(
           <Provider store={store}>
-            <RouterContext {...content}/>
+            <RouterContext {...content} />
           </Provider>
         );
         // render `/view/main.handlebars`, but pass in the markup we want it to display
         res.render('main', {
-                              app: markup,
-                              preloadedState: preloadedState
-                            });
+          app: markup,
+          preloadedState,
+        });
       });
     } else {
       // no route match, so 404. In a real app you might render a custom
       // 404 view here
-      console.log('***404***');
+      console.log(`***404 - ${req.url} ***`);
       res.sendStatus(404);
     }
   });

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,11 +1,11 @@
 import { createStore, applyMiddleware } from 'redux';
-import rootReducer from '../reducers/reducers';
 import reduxImmutableStateInvariant from 'redux-immutable-state-invariant';
 import thunk from 'redux-thunk';
+import rootReducer from '../reducers/reducers';
 
 export default function configureStore(initialState) {
-  console.log('initialState');
-  console.log(initialState);
+  // console.log('initialState');
+  // console.log(initialState);
   return createStore(
     rootReducer,
     initialState,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Makes all but the top-level config.json file for each jurisdiction deletable so that they only operate as augmentations and overrides.

## Related Issue
[https://github.com/CodeForNC/reentry-resources-hub/issues/54](https://github.com/CodeForNC/reentry-resources-hub/issues/54)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If a change is made to the format of content files it is necessary to change the corresponding files in all 100 counties for all topics, which is onerous. The code should work even if a local jurisdiction has no topic files or only a subset. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
